### PR TITLE
Evaluate can perform every defined op

### DIFF
--- a/src/ast/expr.h
+++ b/src/ast/expr.h
@@ -1,9 +1,11 @@
 #pragma once
 #include "../lexer/token.h"
 #include <memory>
+#include <stdexcept>
 
 struct Expr {
     virtual ~Expr() = default;
+    virtual double eval()= 0;
 };
 
 struct Binary : Expr {
@@ -14,17 +16,42 @@ struct Binary : Expr {
     Binary(std::unique_ptr<Expr> left, Token op, std::unique_ptr<Expr> right)
         : left(std::move(left)), op(op), right(std::move(right)) {
     }
+
+    double eval() override {
+        switch (op.type) {
+            case tokenType::PLUS:
+                return left->eval() + right->eval();
+            case tokenType::MINUS:
+                return left->eval() - right->eval();
+            case tokenType::STAR:
+                return left->eval() * right->eval();
+            case tokenType::SLASH:
+                if (right->eval() == 0.0) {
+                    throw std::runtime_error("Division by zero error");
+                }
+                return left->eval() / right->eval();
+            default:
+                throw std::runtime_error("Operador desconocido");
+		}
+    }
+
 };
 
 struct Literal : Expr {
     double value;
     explicit Literal(double value) : value(value) {}
+    double eval() override {
+        return value;
+    }
 };
 
 struct Grouping : Expr {
     std::unique_ptr<Expr> expression;
     explicit Grouping(std::unique_ptr<Expr> expression)
         : expression(std::move(expression)) {
+    }
+    double eval() override {
+        return expression->eval();
     }
 };
 
@@ -34,5 +61,15 @@ struct Unary : Expr {
 
     Unary(Token op, std::unique_ptr<Expr> right)
         : op(op), right(std::move(right)) {
+    }
+    double eval() override {
+        switch (op.type) {
+        case tokenType::PLUS:
+            return right->eval();
+        case tokenType::MINUS:
+            return -right->eval();
+        default:
+            throw std::runtime_error("Operador desconocido");
+        }
     }
 };

--- a/src/main/main.cpp
+++ b/src/main/main.cpp
@@ -41,9 +41,11 @@ int main() {
 
             Parser parser(lexer.getTokens());
             auto ast = parser.parse();
+            auto result = ast->eval();
 
             std::cout << "AST creado exitosamente\n";
             parser.printAST(ast.get());
+            std::cout << "Resultado: " << result << "\n";
         }
         catch (const std::exception& e) {
             std::cout << "Error: " << e.what() << "\n";

--- a/src/runtime/interpreter.cpp
+++ b/src/runtime/interpreter.cpp
@@ -1,0 +1,1 @@
+#include "interpreter.h"

--- a/src/runtime/interpreter.h
+++ b/src/runtime/interpreter.h
@@ -1,0 +1,10 @@
+#ifndef CPP_INTERPRETER_INTERPRETER_H
+#define CPP_INTERPRETER_INTERPRETER_H
+
+// Interpreter implementation goes here
+
+class Interpreter {
+
+};
+
+#endif //CPP_INTERPRETER_INTERPRETER_H


### PR DESCRIPTION
Add expression evaluation and runtime error handling

Introduced the `eval()` method in the `Expr` hierarchy to evaluate expressions, supporting binary, unary, and grouped operations. Added error handling for division by zero and unknown operators. Updated `main.cpp` to evaluate and print AST results. Included `interpreter.h` and added a placeholder `Interpreter` class.