### PR TITLE
test: esqueleto de tests con doctest (base para #19)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,3 +10,10 @@ add_executable(
     src/main/main.cpp
     src/lexer/lexer.cpp
   "src/ast/expr.h" "src/parser/parser.h" "src/parser/parser.cpp")
+
+# Tests (opcional). Configurar con: cmake -B build -DBUILD_TESTING=ON
+option(BUILD_TESTING "Compilar la suite de tests" OFF)
+if(BUILD_TESTING)
+    enable_testing()
+    add_subdirectory(tests)
+endif()

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,0 +1,30 @@
+# Esqueleto de tests para CMathMath.
+# Usa doctest (single-header) traído con FetchContent: no hay que instalar nada.
+include(FetchContent)
+
+# doctest v2.4.11 declara un cmake_minimum_required antiguo; este ajuste permite
+# que sea configurable por versiones modernas de CMake (>= 4.0).
+set(CMAKE_POLICY_VERSION_MINIMUM 3.5)
+
+FetchContent_Declare(
+    doctest
+    GIT_REPOSITORY https://github.com/doctest/doctest.git
+    GIT_TAG        v2.4.11
+)
+FetchContent_MakeAvailable(doctest)
+
+add_executable(cmathmath_tests
+    test_main.cpp
+    test_lexer.cpp
+    test_parser.cpp
+    test_evaluator.cpp
+    # Fuentes del proyecto bajo prueba (expr.h es header-only):
+    ${CMAKE_SOURCE_DIR}/src/lexer/lexer.cpp
+    ${CMAKE_SOURCE_DIR}/src/parser/parser.cpp
+)
+
+# Permite incluir como "lexer/lexer.h", "parser/parser.h", etc.
+target_include_directories(cmathmath_tests PRIVATE ${CMAKE_SOURCE_DIR}/src)
+target_link_libraries(cmathmath_tests PRIVATE doctest::doctest)
+
+add_test(NAME cmathmath_tests COMMAND cmathmath_tests)

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,52 @@
+# Tests de CMathMath
+
+Esqueleto de pruebas automatizadas para el proyecto. Es el punto de partida del
+issue #19; los ejemplos ya funcionan y los comentarios `TODO(Alex, #N)` marcan lo
+que falta por cubrir, enlazado a su issue.
+
+## Framework
+
+Usamos [doctest](https://github.com/doctest/doctest) (single-header). No hay que
+instalar nada: CMake lo descarga con `FetchContent` al configurar.
+
+## Cómo compilar y ejecutar
+
+Desde la raíz del repositorio:
+
+```bash
+cmake -B build -DBUILD_TESTING=ON
+cmake --build build
+ctest --test-dir build --output-on-failure
+```
+
+O ejecutar el binario de tests directamente (salida más detallada):
+
+```bash
+./build/tests/cmathmath_tests
+```
+
+## Estructura
+
+| Archivo               | Qué prueba                                        |
+|-----------------------|---------------------------------------------------|
+| `test_main.cpp`       | Genera el `main()` de doctest (no editar).        |
+| `test_lexer.cpp`      | Tokenización: números, operadores, espacios.      |
+| `test_parser.cpp`     | Construcción del AST y rechazo de entradas inválidas. |
+| `test_evaluator.cpp`  | Resultado numérico de evaluar el AST.             |
+
+## Cómo agregar un test
+
+```cpp
+TEST_CASE("descripción clara de lo que se prueba") {
+    CHECK(expresion_a_evaluar == valor_esperado);
+}
+```
+
+- `CHECK` registra el fallo y continúa; `REQUIRE` aborta el caso si falla.
+- Para `double` usa `doctest::Approx(...)` y evita comparar con `==` directo.
+- Para errores esperados usa `CHECK_THROWS(...)`.
+
+## Pendientes (ver issues)
+
+- **#15** comparación e igualdad · **#16** booleanos/nil/`!` · **#17** doble evaluación
+- **#26** carácter inválido debe lanzar error · **#27** asociatividad tras renombrar reglas

--- a/tests/test_evaluator.cpp
+++ b/tests/test_evaluator.cpp
@@ -1,0 +1,39 @@
+// Tests de evaluación: comprueban el resultado numérico de evaluar el AST.
+#include <doctest/doctest.h>
+#include <string>
+#include "lexer/lexer.h"
+#include "parser/parser.h"
+
+// Helper: de texto fuente al valor evaluado.
+static double eval(const std::string& src) {
+    Lexer lexer(src);
+    lexer.scanTokens();
+    Parser parser(lexer.getTokens());
+    return parser.parse()->eval();
+}
+
+TEST_CASE("Evaluador: aritmética básica") {
+    CHECK(eval("2 + 3")  == doctest::Approx(5.0));
+    CHECK(eval("10 - 4") == doctest::Approx(6.0));
+    CHECK(eval("6 * 7")  == doctest::Approx(42.0));
+    CHECK(eval("8 / 2")  == doctest::Approx(4.0));
+}
+
+TEST_CASE("Evaluador: respeta la precedencia y los paréntesis") {
+    CHECK(eval("2 + 3 * 4")   == doctest::Approx(14.0));
+    CHECK(eval("(2 + 3) * 4") == doctest::Approx(20.0));
+}
+
+TEST_CASE("Evaluador: el menos unario funciona") {
+    CHECK(eval("-5")     == doctest::Approx(-5.0));
+    CHECK(eval("3 * -2") == doctest::Approx(-6.0));
+}
+
+TEST_CASE("Evaluador: la división por cero lanza error") {
+    CHECK_THROWS(eval("1 / 0"));
+}
+
+// TODO(Alex, #15): comparaciones e igualdad deben evaluar a 1.0 (true) / 0.0 (false).
+// TODO(Alex, #16): truthiness de booleanos y nil; comportamiento del operador !.
+// TODO(Alex, #17): tras corregir la doble evaluación, añadir un test con efectos
+//   secundarios que falle si el operando derecho se evalúa dos veces.

--- a/tests/test_lexer.cpp
+++ b/tests/test_lexer.cpp
@@ -1,0 +1,48 @@
+// Tests del Lexer. Los TEST_CASE de abajo son ejemplos funcionales que sirven
+// de plantilla; los comentarios TODO marcan lo que falta por cubrir (issue #19).
+#include <doctest/doctest.h>
+#include "lexer/lexer.h"
+
+TEST_CASE("Lexer: tokeniza una suma simple") {
+    Lexer lexer("1+2");
+    lexer.scanTokens();
+    const auto& tokens = lexer.getTokens();
+
+    REQUIRE(tokens.size() == 4); // NUMBER PLUS NUMBER EOF
+    CHECK(tokens[0].type == tokenType::NUMBER);
+    CHECK(tokens[0].lexeme == "1");
+    CHECK(tokens[1].type == tokenType::PLUS);
+    CHECK(tokens[2].type == tokenType::NUMBER);
+    CHECK(tokens[3].type == tokenType::EOF_TOKEN);
+}
+
+TEST_CASE("Lexer: reconoce números decimales de varios dígitos") {
+    Lexer lexer("3.14");
+    lexer.scanTokens();
+    const auto& tokens = lexer.getTokens();
+
+    REQUIRE(tokens.size() == 2); // NUMBER EOF
+    CHECK(tokens[0].type == tokenType::NUMBER);
+    CHECK(tokens[0].lexeme == "3.14");
+}
+
+TEST_CASE("Lexer: ignora los espacios en blanco") {
+    Lexer lexer("  7   *  ( 8 )  ");
+    lexer.scanTokens();
+    const auto& tokens = lexer.getTokens();
+
+    REQUIRE(tokens.size() == 6); // NUMBER STAR LPAREN NUMBER RPAREN EOF
+    CHECK(tokens[0].lexeme == "7");
+    CHECK(tokens[1].type == tokenType::STAR);
+    CHECK(tokens[2].type == tokenType::LPAREN);
+}
+
+// TODO(Alex, #26): un carácter inválido debe lanzar un error, no producir un EOF_TOKEN.
+//   Cuando #26 esté resuelto, descomenta este caso:
+// TEST_CASE("Lexer: un caracter invalido lanza error") {
+//     Lexer lexer("2 @ 3");
+//     CHECK_THROWS(lexer.scanTokens());
+// }
+
+// TODO(Alex, #15): añadir casos para los tokens de comparación e igualdad (== != < > <= >=).
+// TODO(Alex, #16): añadir casos para las palabras clave true/false/nil y el operador !.

--- a/tests/test_main.cpp
+++ b/tests/test_main.cpp
@@ -1,0 +1,4 @@
+// Punto de entrada de doctest. Genera el main() de la suite de tests.
+// No agregues casos de prueba aquí: ponlos en los archivos test_*.cpp.
+#define DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
+#include <doctest/doctest.h>

--- a/tests/test_parser.cpp
+++ b/tests/test_parser.cpp
@@ -1,0 +1,35 @@
+// Tests del Parser. Comprueban que una cadena de tokens válida produce un AST
+// y que las entradas mal formadas son rechazadas.
+#include <doctest/doctest.h>
+#include <memory>
+#include <string>
+#include "lexer/lexer.h"
+#include "parser/parser.h"
+
+// Helper: de texto fuente a AST.
+static std::unique_ptr<Expr> parse(const std::string& src) {
+    Lexer lexer(src);
+    lexer.scanTokens();
+    Parser parser(lexer.getTokens());
+    return parser.parse();
+}
+
+TEST_CASE("Parser: una expresión válida construye un AST") {
+    auto ast = parse("(1 + 2) * 3");
+    REQUIRE(ast != nullptr);
+}
+
+TEST_CASE("Parser: tokens sobrantes son un error") {
+    CHECK_THROWS(parse("1 2"));
+}
+
+TEST_CASE("Parser: falta el paréntesis de cierre") {
+    CHECK_THROWS(parse("(1 + 2"));
+}
+
+TEST_CASE("Parser: un operador sin operando derecho es un error") {
+    CHECK_THROWS(parse("3 +"));
+}
+
+// TODO(Alex, #27): tras renombrar term/factor para alinearlos con la gramática,
+//   añadir tests de asociatividad que fijen la precedencia (p. ej. 2 - 3 - 4).


### PR DESCRIPTION
## ¿Qué es esto?

Un **punto de partida** para la suite de tests automatizados (issue #19). No pretende cerrar #19: monta toda la infraestructura y deja ejemplos funcionando para que tú, @AlejandroPuenteFragoso, completes la cobertura siguiendo el patrón.

Está en **borrador** a propósito: es un ejercicio de revisión. Léelo, ejecútalo, y cuando lo entiendas lo marcamos listo para merge.

---

## ¿Por qué tests?

Hasta ahora la única forma de verificar el intérprete es escribir a mano en el REPL y mirar la salida. Eso no escala: cada vez que toques el Lexer o el Parser podrías romper algo sin darte cuenta. Una suite de tests es una **red de seguridad** — corre en segundos y te avisa al instante si una regresión rompió algo que antes funcionaba.

---

## Cómo probarlo

Desde la raíz del repo:

```bash
cmake -B build -DBUILD_TESTING=ON
cmake --build build
ctest --test-dir build --output-on-failure
```

Resultado esperado: `100% tests passed` (11 casos, 26 aserciones).

Para ver el detalle de cada caso, ejecuta el binario directamente:

```bash
./build/tests/cmathmath_tests
```

---

## Qué incluye y por qué

| Archivo | Rol |
|---|---|
| `tests/CMakeLists.txt` | Trae **doctest** con `FetchContent` (no instalas nada en tu máquina). |
| `tests/test_main.cpp` | Genera el `main()` de doctest. No se tocan tests aquí. |
| `tests/test_lexer.cpp` | Tokenización: números, operadores, espacios. |
| `tests/test_parser.cpp` | Construcción del AST y rechazo de entradas inválidas. |
| `tests/test_evaluator.cpp` | Resultado numérico de evaluar el AST. |
| `tests/README.md` | Cómo compilar/ejecutar y cómo añadir un test. |

**Decisiones de diseño que vale la pena que notes:**

1. **doctest vía `FetchContent`**: es un framework *single-header*; CMake lo descarga solo. Así nadie tiene que instalar dependencias a mano.
2. **`option(BUILD_TESTING ...)` está en `OFF` por defecto** en el `CMakeLists` raíz: compilar el ejecutable normal no descarga ni compila los tests. Solo se activan con `-DBUILD_TESTING=ON`. Lo dejé mínimo para no chocar con la limpieza de CMake del #20.
3. **`set(CMAKE_POLICY_VERSION_MINIMUM 3.5)`**: doctest v2.4.11 declara un `cmake_minimum_required` antiguo que CMake 4 rechaza; esta línea es el workaround. Si te topas con ese error en otra dependencia, ya sabes de dónde viene.
4. Los tests reutilizan las **mismas fuentes** del proyecto (`lexer.cpp`, `parser.cpp`); no hay código duplicado.

---

## Tu tarea (lo que falta)

Busca los comentarios `// TODO(Alex, #N):` repartidos por los archivos. Cada uno apunta al issue que habilita ese test:

- **#26** — al corregir el carácter inválido, descomenta el test `CHECK_THROWS(lexer.scanTokens())`.
- **#15** — añade casos para `== != < > <= >=`.
- **#16** — añade casos para `true`/`false`/`nil` y el operador `!`.
- **#17** — tras corregir la doble evaluación, añade un test que falle si el operando derecho se evalúa dos veces.
- **#27** — tras renombrar `term`/`factor`, añade tests de asociatividad/precedencia.

Patrón para un test nuevo:

```cpp
TEST_CASE("descripción clara de lo que se prueba") {
    CHECK(eval("2 + 3") == doctest::Approx(5.0)); // usa Approx para double
    CHECK_THROWS(eval("1 / 0"));                   // para errores esperados
}
```

---

Relacionado con #19. No lo cierra: el objetivo es que tú lo lleves a una suite completa.