### PR TITLE
Fase1 issue32

### DIFF
--- a/src/lexer/lexer.cpp
+++ b/src/lexer/lexer.cpp
@@ -168,7 +168,9 @@ tokenType Lexer::createToken(const std::string& value)
         if (hasDigits) return tokenType::NUMBER;
     }
 
-    return tokenType::EOF_TOKEN;
+    throw std::runtime_error(
+        "Unexpected character: " + value
+    );
 }
 
 

--- a/tests/test_lexer.cpp
+++ b/tests/test_lexer.cpp
@@ -74,3 +74,23 @@ TEST_CASE("Lexer: reconoce operadores de comparacion e igualdad") {
     CHECK(tokens[6].lexeme.empty());
 }
 // TODO(Alex, #16): añadir casos para las palabras clave true/false/nil y el operador !.
+
+TEST_CASE("Lexer rechaza caracteres invalidos") {
+    Lexer lexerEqual("5 = 5");
+    CHECK_THROWS_WITH(
+        lexerEqual.scanTokens(),
+        "Unexpected character: ="
+    );
+
+    Lexer lexerBang("3 ! 2");
+    CHECK_THROWS_WITH(
+        lexerBang.scanTokens(),
+        "Unexpected character: !"
+    );
+
+    Lexer lexerUnknown("5 @ 5");
+    CHECK_THROWS_WITH(
+        lexerUnknown.scanTokens(),
+        "Unexpected character: @"
+    );
+}


### PR DESCRIPTION
Se actualizó el lexer para lanzar std::runtime_error cuando encuentra caracteres u operadores no reconocidos, como =, ! o @.
Anteriormente, estos caracteres producían un EOF_TOKEN, provocando que expresiones como 5 = 5 se truncaran y evaluaran silenciosamente. Ahora EOF_TOKEN se utiliza únicamente para representar el final real de la entrada.
También se agregaron pruebas para verificar el error y su mensaje correspondiente.
Closes #32