### PR TITLE
ci: workflow de GitHub Actions para los tests unitarios

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,39 @@
+name: Tests
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  tests:
+    name: ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Cachear dependencias de FetchContent
+        uses: actions/cache@v4
+        with:
+          path: build/_deps
+          key: deps-${{ matrix.os }}-${{ hashFiles('tests/CMakeLists.txt') }}
+
+      - name: Configurar
+        run: cmake -B build -DBUILD_TESTING=ON -DCMAKE_BUILD_TYPE=Release
+
+      - name: Compilar
+        run: cmake --build build --config Release
+
+      - name: Ejecutar tests
+        run: ctest --test-dir build -C Release --output-on-failure

--- a/README.md
+++ b/README.md
@@ -1,0 +1,13 @@
+# CMathMath
+
+[![Tests](https://github.com/AlejandroPuenteFragoso/CMathMath/actions/workflows/tests.yml/badge.svg)](https://github.com/AlejandroPuenteFragoso/CMathMath/actions/workflows/tests.yml)
+
+Intérprete de expresiones matemáticas escrito en C++.
+
+## Compilar y ejecutar los tests
+
+```sh
+cmake -B build -DBUILD_TESTING=ON
+cmake --build build
+ctest --test-dir build --output-on-failure
+```


### PR DESCRIPTION
Añade integración continua para la suite de tests. El repo no tenía `.github/`.

## Qué hace

`.github/workflows/tests.yml` configura, compila y ejecuta los tests en cada push a `main` y en **cada pull request**:

```sh
cmake -B build -DBUILD_TESTING=ON -DCMAKE_BUILD_TYPE=Release
cmake --build build --config Release
ctest --test-dir build -C Release --output-on-failure
```

Detalles:

- **Matriz `ubuntu-latest` + `windows-latest`**, con `fail-fast: false` para que un fallo en un SO no oculte el resultado del otro. Windows aporta cobertura real porque parte del equipo desarrolla en Visual Studio.
- `--config Release` es necesario en los tres pasos porque MSVC es multi-config.
- **Caché** de `build/_deps`, con clave sobre `tests/CMakeLists.txt`, para no reclonar doctest en cada run.
- **`concurrency` con `cancel-in-progress`**: un push nuevo cancela el run anterior de esa rama.
- `workflow_dispatch` para poder lanzarlo a mano.

El disparador de `pull_request` no filtra por rama destino, así que las PRs hacia ramas intermedias como `Fase1` también quedan cubiertas, no solo las que apuntan a `main`.

## README

Estaba vacío. Añado únicamente el badge de CI, una línea de descripción y los comandos de test, para que el badge tenga contexto. La documentación completa sigue pendiente en #21.

## Verificación

Probado en local (macOS): la secuencia exacta de los tres comandos configura, compila y pasa — `1/1 Test #1: cmathmath_tests ... Passed`, 18/18 casos de doctest. El job de Windows se verifica con el primer run de esta PR.
