### PR TITLE
docs: documentar los headers públicos con Doxygen (evaluación de #40)

### DIFF
--- a/src/ast/expr.h
+++ b/src/ast/expr.h
@@ -3,20 +3,48 @@
 #include <memory>
 #include <stdexcept>
 
+/**
+ * @brief Base node of the expression AST built by the Parser.
+ *
+ * Every node owns its children through std::unique_ptr, so destroying the
+ * root releases the whole tree. Evaluation is a recursive walk started by
+ * calling eval() on the root.
+ */
 struct Expr {
     virtual ~Expr() = default;
+
+    /**
+     * @brief Computes the value of this subtree.
+     *
+     * Every value in the language is a double for now; comparisons yield
+     * 1.0 (true) or 0.0 (false) until a boolean type exists (issue #16).
+     *
+     * @return The numeric result of the subtree.
+     * @throws std::runtime_error on runtime errors, e.g. division by zero.
+     */
     virtual double eval()= 0;
 };
 
+/**
+ * @brief Node for a binary operation: arithmetic, comparison or equality.
+ *
+ * Which operation applies is decided at evaluation time from `op.type`.
+ */
 struct Binary : Expr {
-    std::unique_ptr<Expr> left;
-    Token op;
-    std::unique_ptr<Expr> right;
+    std::unique_ptr<Expr> left;  ///< Left operand; evaluated first.
+    Token op;                    ///< Operator token; its type selects the operation.
+    std::unique_ptr<Expr> right; ///< Right operand.
 
     Binary(std::unique_ptr<Expr> left, Token op, std::unique_ptr<Expr> right)
         : left(std::move(left)), op(op), right(std::move(right)) {
     }
 
+    /**
+     * @brief Evaluates both operands (left first, exactly once each) and applies `op`.
+     * @return The arithmetic result, or 1.0/0.0 for comparisons and equality.
+     * @throws std::runtime_error on division by zero, or if `op` is not a
+     *         binary operator this node knows how to apply.
+     */
     double eval() override {
         double leftValue = left->eval();
         double rightValue = right->eval();
@@ -57,31 +85,57 @@ struct Binary : Expr {
 
 };
 
+/**
+ * @brief Leaf node holding a numeric literal, already parsed to double.
+ */
 struct Literal : Expr {
-    double value;
+    double value; ///< The literal's value, converted by the Parser with std::stod.
     explicit Literal(double value) : value(value) {}
+
+    /// @return The stored value. Never throws.
     double eval() override {
         return value;
     }
 };
 
+/**
+ * @brief Node for a parenthesized expression.
+ *
+ * Carries no behavior of its own — grouping already shaped the tree during
+ * parsing — but preserves the parentheses so tools like printAST can show
+ * the source structure faithfully.
+ */
 struct Grouping : Expr {
-    std::unique_ptr<Expr> expression;
+    std::unique_ptr<Expr> expression; ///< The expression inside the parentheses.
     explicit Grouping(std::unique_ptr<Expr> expression)
         : expression(std::move(expression)) {
     }
+
+    /// @return The inner expression's value, unchanged.
     double eval() override {
         return expression->eval();
     }
 };
 
+/**
+ * @brief Node for a unary prefix operator applied to one operand.
+ *
+ * Only unary plus and minus exist today; logical not ("!") arrives with
+ * issue #16.
+ */
 struct Unary : Expr {
-    Token op;
-    std::unique_ptr<Expr> right;
+    Token op;                    ///< Operator token: PLUS or MINUS.
+    std::unique_ptr<Expr> right; ///< Operand the operator applies to.
 
     Unary(Token op, std::unique_ptr<Expr> right)
         : op(op), right(std::move(right)) {
     }
+
+    /**
+     * @brief Evaluates the operand and applies the prefix operator.
+     * @return The operand's value, negated when `op` is MINUS.
+     * @throws std::runtime_error if `op` is not a supported unary operator.
+     */
     double eval() override {
         switch (op.type) {
         case tokenType::PLUS:

--- a/src/lexer/lexer.h
+++ b/src/lexer/lexer.h
@@ -4,26 +4,86 @@
 #include <string>
 #include <vector>
 
+/**
+ * @brief Converts a source string into the flat list of tokens the Parser consumes.
+ *
+ * Usage: construct with the input, call scanTokens() exactly once, then read
+ * the result with getTokens(). Scanning is eager: the whole input is
+ * tokenized in one pass, and any lexical error aborts it with an exception.
+ */
 class Lexer
 {
 public:
+	/**
+	 * @brief Prepares a lexer over the given source text; nothing is scanned yet.
+	 * @param input Expression source. The lexer keeps its own copy.
+	 */
 	Lexer(const std::string& input);
 
+	/// @brief Moves the cursor one character forward. Does not check bounds.
 	void advance();
+
+	/**
+	 * @brief Looks at the character under the cursor without consuming it.
+	 * @return The current character, or '\0' when the cursor is past the end.
+	 */
 	char peek();
+
+	/**
+	 * @brief Looks one character beyond the cursor without consuming anything.
+	 * @return The next character, or '\0' when it would fall past the end.
+	 */
 	char peekNext();
+
+	/// @return true once the cursor has consumed the entire input.
 	bool isAtEnd();
 
+	/// @brief Advances the cursor past any run of whitespace (spaces, tabs, newlines).
 	void skipWhitespace();
+
+	/**
+	 * @brief Tokenizes the entire input and stores the result.
+	 *
+	 * Recognizes numeric literals, arithmetic operators, parentheses and the
+	 * comparison/equality operators, including the two-character forms
+	 * ("==", "!=", "<=", ">="). Always appends a final EOF_TOKEN sentinel.
+	 * Call it once per Lexer: a second call would append a duplicate stream.
+	 *
+	 * @throws std::runtime_error if the input contains a malformed number or
+	 *         any character outside the language (a lone '=' or '!' included).
+	 */
 	void scanTokens();
+
+	/**
+	 * @brief Scans one numeric literal and appends its NUMBER token.
+	 *
+	 * Precondition: the character under the cursor is a digit and `start`
+	 * marks where the literal begins. Accepts integers and decimals; a
+	 * decimal point must be followed by at least one digit.
+	 *
+	 * @throws std::runtime_error on malformed literals such as "3." or "1.2.3".
+	 */
 	void scanNumber();
+
+	/**
+	 * @brief Classifies an operator or parenthesis lexeme.
+	 * @param value Lexeme to classify, e.g. "+", "(", "<=".
+	 * @return The matching category; NUMBER when the lexeme is a numeric string.
+	 * @throws std::runtime_error ("Unexpected character: ...") when the lexeme
+	 *         is not part of the language. This is what rejects invalid input
+	 *         instead of silently truncating it.
+	 */
 	tokenType createToken(const std::string& value);
 
+	/**
+	 * @return The tokens produced by scanTokens(), ending in EOF_TOKEN.
+	 *         Empty if scanTokens() has not run yet.
+	 */
 	const std::vector<Token>& getTokens() const;
 
 private:
-	std::string input;
-	size_t current = 0;
-	size_t start = 0;
-	std::vector<Token> tokens;
+	std::string input;         ///< Full source text being scanned.
+	size_t current = 0;        ///< Cursor: index of the next character to consume.
+	size_t start = 0;          ///< Index where the lexeme in progress begins.
+	std::vector<Token> tokens; ///< Output, filled by scanTokens().
 };

--- a/src/lexer/token.h
+++ b/src/lexer/token.h
@@ -3,14 +3,25 @@
 #include <string>
 #include <cctype>
 
+/**
+ * @brief A lexical unit produced by the Lexer.
+ *
+ * Pairs a token category with the exact source text it was scanned from.
+ * Tokens are plain value objects: the Lexer builds them and the Parser
+ * only reads them.
+ */
 class Token
 {
 public:
+    /**
+     * @brief Builds a token of the given category.
+     * @param type   Category the Parser will dispatch on.
+     * @param lexeme Verbatim source text of the token. Empty only for the
+     *               EOF_TOKEN sentinel.
+     */
     Token(tokenType type, const std::string& lexeme)
         : type(type), lexeme(lexeme) {}
 
-    tokenType type;
-    std::string lexeme;
-
-   
+    tokenType type;     ///< Category the Parser dispatches on.
+    std::string lexeme; ///< Verbatim source text; for NUMBER it is parseable by std::stod.
 };

--- a/src/lexer/tokenType.h
+++ b/src/lexer/tokenType.h
@@ -1,24 +1,37 @@
 #pragma once
 #include <string>
+
+/**
+ * @brief Categories of the lexical units the language understands.
+ *
+ * Produced by Lexer::createToken and consumed by the Parser to decide
+ * which grammar rule applies.
+ */
 enum class tokenType
 {
-	NUMBER,
-	PLUS,
-	MINUS,
-	STAR,
-	SLASH,
-	LPAREN,
-	RPAREN,
-    EQUAL_EQUAL,
-    BANG_EQUAL,
-    LESS,
-    LESS_EQUAL,
-    GREATER,
-    GREATER_EQUAL,
-	EOF_TOKEN,
+	NUMBER,        ///< Numeric literal: integer or decimal with digits after the point.
+	PLUS,          ///< Binary addition or unary plus: "+".
+	MINUS,         ///< Binary subtraction or unary negation: "-".
+	STAR,          ///< Multiplication: "*".
+	SLASH,         ///< Division: "/".
+	LPAREN,        ///< Opening parenthesis: "(".
+	RPAREN,        ///< Closing parenthesis: ")".
+    EQUAL_EQUAL,   ///< Equality: "==". A lone "=" is not part of the language.
+    BANG_EQUAL,    ///< Inequality: "!=". A lone "!" is not part of the language.
+    LESS,          ///< Comparison: "<".
+    LESS_EQUAL,    ///< Comparison: "<=".
+    GREATER,       ///< Comparison: ">".
+    GREATER_EQUAL, ///< Comparison: ">=".
+	EOF_TOKEN,     ///< Sentinel appended after the last real token; its lexeme is empty.
 
 };
 
+/**
+ * @brief Returns the identifier of a category as text, for logs and debugging.
+ * @param type Category to name.
+ * @return The enumerator's own name, e.g. "NUMBER"; "UNKNOWN" if the value
+ *         does not match any enumerator.
+ */
 inline std::string tokenTypeToString(tokenType type)
 {
     switch (type) {

--- a/src/parser/parser.h
+++ b/src/parser/parser.h
@@ -4,27 +4,86 @@
 #include <vector>
 #include <memory>
 
+/**
+ * @brief Recursive-descent parser that turns a token list into an AST.
+ *
+ * Each private method implements one rule of the grammar (docs/grammar.md),
+ * from lowest to highest precedence:
+ *
+ *   expression -> equality
+ *   equality   -> comparison (("==" | "!=") comparison)*
+ *   comparison -> additive ((">" | ">=" | "<" | "<=") additive)*
+ *   additive   -> term (("+" | "-") term)*
+ *   term       -> factor (("*" | "/") factor)*
+ *   factor     -> unary
+ *   unary      -> ("+" | "-") unary | primary
+ *   primary    -> NUMBER | "(" expression ")"
+ *
+ * The input must come from Lexer::getTokens(), so it always ends with an
+ * EOF_TOKEN sentinel.
+ */
 class Parser {
 public:
+    /**
+     * @brief Prepares a parser over a token stream; nothing is parsed yet.
+     * @param tokens Token list ending in EOF_TOKEN. The parser keeps a copy.
+     */
     explicit Parser(const std::vector<Token>& tokens);
+
+    /**
+     * @brief Parses the whole token stream as a single expression.
+     * @return Root of the resulting AST; evaluate it with Expr::eval().
+     * @throws std::runtime_error if the stream is not one well-formed
+     *         expression: unexpected token, missing ')' or trailing tokens
+     *         after the expression (e.g. "1 2").
+     */
     std::unique_ptr<Expr> parse();
+
+    /**
+     * @brief Prints the tree shape of an AST to stdout, for debugging.
+     * @param expr   Root of the subtree to print. Must not be null.
+     * @param indent Depth of the current node; two spaces per level.
+     */
     void printAST(Expr* expr, int indent = 0);
 
 private:
-    std::vector<Token> tokens;
-    size_t current = 0;
+    std::vector<Token> tokens; ///< Input stream, always terminated by EOF_TOKEN.
+    size_t current = 0;        ///< Index of the next token to consume.
 
+    /// @brief expression -> equality. Entry rule, lowest precedence.
     std::unique_ptr<Expr> expression();
+    /// @brief term -> factor (("*" | "/") factor)*. Left-associative.
     std::unique_ptr<Expr> term();
+    /// @brief factor -> unary. Passthrough level (see issue #27).
     std::unique_ptr<Expr> factor();
+    /// @brief unary -> ("+" | "-") unary | primary. Right-associative by recursion.
     std::unique_ptr<Expr> unary();
+    /**
+     * @brief primary -> NUMBER | "(" expression ")". Highest precedence.
+     * @throws std::runtime_error on any other token, or if the ')' is missing.
+     */
     std::unique_ptr<Expr> primary();
+    /**
+     * @brief equality -> comparison (("==" | "!=") comparison)*. Left-associative:
+     *        chains like "a == b == c" parse as "(a == b) == c" (see issue #39).
+     */
     std::unique_ptr<Expr> equality();
+    /// @brief comparison -> additive ((">" | ">=" | "<" | "<=") additive)*. Left-associative.
     std::unique_ptr<Expr> comparison();
+    /// @brief additive -> term (("+" | "-") term)*. Left-associative.
     std::unique_ptr<Expr> additive();
+
+    /// @brief Consumes the current token. @return The token just consumed.
     Token advance();
+    /// @return The current token without consuming it; EOF_TOKEN at the end.
     Token peek();
+    /// @return true when the current token is EOF_TOKEN (or the stream ran out).
     bool isAtEnd();
+    /// @return true if the current token is of the given type. Consumes nothing.
     bool check(tokenType type);
+    /**
+     * @brief Consumes the current token only if it matches the given type.
+     * @return true if it matched and was consumed; false leaves the cursor untouched.
+     */
     bool match(tokenType type);
 };


### PR DESCRIPTION
## Qué hace

Documenta los cinco headers públicos (`lexer.h`, `token.h`, `tokenType.h`, `parser.h`, `expr.h`) con sintaxis Doxygen: `@brief`, `@param`, `@return` y `@throws`. **Sin cambios de código — solo comentarios** (verificado: compila y la suite de tests pasa igual que en `Fase1`).

Sirve como ejemplo de referencia para la evaluación de #40: así se vería el codebase documentado con Doxygen.

## Criterios aplicados

- **Contratos, no paráfrasis**: cada comentario dice qué recibe la función, qué garantiza y qué lanza (con los mensajes reales de las excepciones), no repite el nombre. Ej.: `Binary::eval()` documenta que evalúa cada operando exactamente una vez — el bug de #29 convertido en contrato explícito.
- **En inglés**, consistente con el resto de comentarios del código.
- **Referencias a los issues abiertos** donde el comportamiento actual es provisional, para que la documentación no lo dé por definitivo: comparaciones como `1.0`/`0.0` (#16), el passthrough `factor → unary` (#27), asociatividad de comparaciones encadenadas (#39).
- La gramática completa quedó en el `@brief` de `Parser`, junto al código que la implementa.
- `interpreter.h` queda fuera (clase vacía, sin contrato que documentar) y no se toca la indentación de `tokenType.h` (eso es #33).

## Cómo verlo

Sin generar nada: en CLion o VS Code, pasar el cursor sobre cualquier función — los tooltips ya renderizan estos comentarios. El target de CMake con `doxygen_add_docs` para generar el HTML sería el siguiente paso si #40 concluye en adoptar.

Ref #40.
