### PR TITLE
issue 39

### DIFF
--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -12,3 +12,14 @@ La regla de *truthiness* sigue a Lox:
 El operador `!` devuelve la negación de esa regla. Las operaciones aritméticas y
 las comparaciones de orden requieren operandos numéricos; la igualdad permite
 comparar cualquier par de valores.
+
+# Comparaciones encadenadas
+
+Las reglas de comparación e igualdad aceptan como máximo un operador por nivel de
+precedencia. Expresiones como `1 < 2 < 3` y `true == false == false` son errores
+sintácticos. Esto evita que el resultado booleano de la primera operación se use
+implícitamente como operando de la segunda.
+
+La restricción se aplica dentro de cada subexpresión. El agrupamiento explícito y
+la combinación de niveles de precedencia siguen permitidos; por ejemplo,
+`(1 < 2) == true` y `1 < 2 == true` son expresiones válidas.

--- a/docs/grammar.md
+++ b/docs/grammar.md
@@ -1,6 +1,6 @@
 expression     → equality ;
-equality       → comparison ( ( "!=" | "==" ) comparison )* ;
-comparison     → term ( ( ">" | ">=" | "<" | "<=" ) term )* ;
+equality       → comparison ( ( "!=" | "==" ) comparison )? ;
+comparison     → term ( ( ">" | ">=" | "<" | "<=" ) term )? ;
 term           → factor ( ( "-" | "+" ) factor )* ;
 factor         → unary ( ( "/" | "*" ) unary )* ;
 unary          → ( "!" | "+" | "-" ) unary

--- a/src/parser/parser.cpp
+++ b/src/parser/parser.cpp
@@ -12,6 +12,19 @@ std::string describeToken(const Token& token)
     return "'" + token.lexeme + "'";
 }
 
+bool isEqualityOperator(tokenType type)
+{
+    return type == tokenType::EQUAL_EQUAL || type == tokenType::BANG_EQUAL;
+}
+
+bool isComparisonOperator(tokenType type)
+{
+    return type == tokenType::LESS ||
+           type == tokenType::LESS_EQUAL ||
+           type == tokenType::GREATER ||
+           type == tokenType::GREATER_EQUAL;
+}
+
 [[noreturn]] void throwParserError(const Token& token, const std::string& message)
 {
     throw std::runtime_error(
@@ -131,25 +144,33 @@ std::unique_ptr<Expr> Parser::primary() {
     );
 }
 
-// equality -> comparison (("==" | "!=") comparison)*
+// equality -> comparison (("==" | "!=") comparison)?
 std::unique_ptr<Expr> Parser::equality() {
     auto expr = comparison();
-    while (match(tokenType::EQUAL_EQUAL) || match(tokenType::BANG_EQUAL)) {
-        Token op = tokens[current - 1];
-        expr = std::make_unique<Binary>(std::move(expr), op, comparison());
+
+    if (isEqualityOperator(peek().type)) {
+        Token op = advance();
+        auto right = comparison();
+        expr = std::make_unique<Binary>(
+            std::move(expr),
+            op,
+            std::move(right)
+        );
     }
+
+    if (isEqualityOperator(peek().type)) {
+        throwParserError(peek(), "Chained comparisons are not supported");
+    }
+
     return expr;
 }
 
-// comparison -> term ((">" | ">=" | "<" | "<=") term)*
+// comparison -> term ((">" | ">=" | "<" | "<=") term)?
 std::unique_ptr<Expr> Parser::comparison() {
     auto expr = term();
 
-    while (match(tokenType::LESS) ||
-           match(tokenType::LESS_EQUAL) ||
-           match(tokenType::GREATER) ||
-           match(tokenType::GREATER_EQUAL)) {
-        Token op = tokens[current - 1];
+    if (isComparisonOperator(peek().type)) {
+        Token op = advance();
         auto right = term();
 
         expr = std::make_unique<Binary>(
@@ -157,6 +178,10 @@ std::unique_ptr<Expr> Parser::comparison() {
             op,
             std::move(right)
         );
+    }
+
+    if (isComparisonOperator(peek().type)) {
+        throwParserError(peek(), "Chained comparisons are not supported");
     }
 
     return expr;

--- a/src/parser/parser.h
+++ b/src/parser/parser.h
@@ -11,8 +11,8 @@
  * from lowest to highest precedence:
  *
  *   expression -> equality
- *   equality   -> comparison (("==" | "!=") comparison)*
- *   comparison -> term ((">" | ">=" | "<" | "<=") term)*
+ *   equality   -> comparison (("==" | "!=") comparison)?
+ *   comparison -> term ((">" | ">=" | "<" | "<=") term)?
  *   term       -> factor (("+" | "-") factor)*
  *   factor     -> unary (("*" | "/") unary)*
  *   unary      -> ("!" | "+" | "-") unary | primary
@@ -33,8 +33,8 @@ public:
      * @brief Parses the whole token stream as a single expression.
      * @return Root of the resulting AST; evaluate it with Expr::eval().
      * @throws std::runtime_error if the stream is not one well-formed
-     *         expression: unexpected token, missing ')' or trailing tokens
-     *         after the expression (e.g. "1 2").
+     *         expression: unexpected token, missing ')', chained comparisons
+     *         or trailing tokens after the expression (e.g. "1 2").
      */
     std::unique_ptr<Expr> parse();
 
@@ -62,12 +62,9 @@ private:
      * @throws std::runtime_error on any other token, or if the ')' is missing.
      */
     std::unique_ptr<Expr> primary();
-    /**
-     * @brief equality -> comparison (("==" | "!=") comparison)*. Left-associative:
-     *        chains like "a == b == c" parse as "(a == b) == c" (see issue #39).
-     */
+    /// @brief equality -> comparison (("==" | "!=") comparison)?.
     std::unique_ptr<Expr> equality();
-    /// @brief comparison -> term ((">" | ">=" | "<" | "<=") term)*. Left-associative.
+    /// @brief comparison -> term ((">" | ">=" | "<" | "<=") term)?.
     std::unique_ptr<Expr> comparison();
 
     /// @brief Consumes the current token. @return The token just consumed.

--- a/tests/test_evaluator.cpp
+++ b/tests/test_evaluator.cpp
@@ -69,6 +69,8 @@ TEST_CASE("Evaluador: respeta precedencia en expresiones relacionales") {
     CHECK(evalBoolean("1 + 2 * 3 == 7"));
     CHECK_FALSE(evalBoolean("1 + 2 > 2 * 2"));
     CHECK(evalBoolean("(1 + 2) * 3 <= 9"));
+    CHECK(evalBoolean("1 < 2 == true"));
+    CHECK(evalBoolean("(1 < 2) == true"));
 }
 
 TEST_CASE("Evaluador: reconoce booleanos y nil") {

--- a/tests/test_parser.cpp
+++ b/tests/test_parser.cpp
@@ -76,6 +76,38 @@ TEST_CASE("Parser: comparacion tiene mayor precedencia que igualdad") {
     CHECK(comparison->op.type == tokenType::LESS);
 }
 
+TEST_CASE("Parser: rechaza comparaciones de orden encadenadas") {
+    CHECK_THROWS_WITH(
+        parse("1 < 2 < 3"),
+        "Error [line 1, column 7]: Chained comparisons are not supported"
+    );
+    CHECK_THROWS_WITH(
+        parse("3 > 2 >= 1"),
+        "Error [line 1, column 7]: Chained comparisons are not supported"
+    );
+    CHECK_THROWS_WITH(
+        parse("1 <= 2 > 0"),
+        "Error [line 1, column 8]: Chained comparisons are not supported"
+    );
+}
+
+TEST_CASE("Parser: rechaza igualdades encadenadas") {
+    CHECK_THROWS_WITH(
+        parse("1 == 1 == true"),
+        "Error [line 1, column 8]: Chained comparisons are not supported"
+    );
+    CHECK_THROWS_WITH(
+        parse("1 != 2 != false"),
+        "Error [line 1, column 8]: Chained comparisons are not supported"
+    );
+}
+
+TEST_CASE("Parser: permite comparaciones agrupadas o en distintos niveles") {
+    CHECK_NOTHROW(parse("1 < 2 == true"));
+    CHECK_NOTHROW(parse("(1 < 2) == true"));
+    CHECK_NOTHROW(parse("(1 < 2) == (2 < 3)"));
+}
+
 TEST_CASE("Parser: construye literales booleanos y nil") {
     auto trueAst = parse("true");
     auto* trueLiteral = dynamic_cast<Literal*>(trueAst.get());


### PR DESCRIPTION
Resolves #39 by rejecting chained comparison and equality operators during parsing, with clear error messages, updated grammar documentation, and regression tests.